### PR TITLE
Remove deprecated python option `-tt`

### DIFF
--- a/daemon/dnfdaemon-session.py
+++ b/daemon/dnfdaemon-session.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -tt
+#!/usr/bin/python3
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2

--- a/daemon/dnfdaemon-system.py
+++ b/daemon/dnfdaemon-system.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -tt
+#!/usr/bin/python3
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
 # as published by the Free Software Foundation; either version 2


### PR DESCRIPTION
Same as timlau/yumex-dnf#58:
The -t option was removed in python3. It has no effect any more and is ignored. It can be safely removed. See https://bugzilla.redhat.com/show_bug.cgi?id=1268262