### PR TITLE
RHEL uses another name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ test/pkgs/repo
 /test/pkgs/dnf-daemon-test.repo
 *~
 build/
+/.idea/

--- a/dnfdaemon.spec
+++ b/dnfdaemon.spec
@@ -48,7 +48,7 @@ Requires:       %{name} = %{version}-%{release}
 %if 0%{?fedora} >= 23 || 0%{?mageia} >= 6 || 0%{?rhel} >= 9
 Requires(post):     policycoreutils-python-utils
 Requires(postun):   policycoreutils-python-utils
-%elseif 0%{?rhel} = 8
+%else %if 0%{?rhel} == 8
 Requires(post):     policycoreutils-python3
 Requires(postun):   policycoreutils-python3
 %else

--- a/dnfdaemon.spec
+++ b/dnfdaemon.spec
@@ -48,6 +48,9 @@ Requires:       %{name} = %{version}-%{release}
 %if 0%{?fedora} >= 23 || 0%{?mageia} >= 6
 Requires(post):     policycoreutils-python-utils
 Requires(postun):   policycoreutils-python-utils
+%elseif 0%{?rhel} >= 8
+Requires(post):     policycoreutils-python3
+Requires(postun):   policycoreutils-python3
 %else
 Requires(post):     policycoreutils-python
 Requires(postun):   policycoreutils-python

--- a/dnfdaemon.spec
+++ b/dnfdaemon.spec
@@ -48,7 +48,7 @@ Requires:       %{name} = %{version}-%{release}
 %if 0%{?fedora} >= 23 || 0%{?mageia} >= 6 || 0%{?rhel} >= 9
 Requires(post):     policycoreutils-python-utils
 Requires(postun):   policycoreutils-python-utils
-%elseif 0%{?rhel} == 8
+%elseif 0%{?rhel} = 8
 Requires(post):     policycoreutils-python3
 Requires(postun):   policycoreutils-python3
 %else

--- a/dnfdaemon.spec
+++ b/dnfdaemon.spec
@@ -48,14 +48,15 @@ Requires:       %{name} = %{version}-%{release}
 %if 0%{?fedora} >= 23 || 0%{?mageia} >= 6 || 0%{?rhel} >= 9
 Requires(post):     policycoreutils-python-utils
 Requires(postun):   policycoreutils-python-utils
-%else %if 0%{?rhel} == 8
+%else
+%if 0%{?rhel} == 8
 Requires(post):     policycoreutils-python3
 Requires(postun):   policycoreutils-python3
 %else
 Requires(post):     policycoreutils-python
 Requires(postun):   policycoreutils-python
 %endif
-
+%endif
 # Use boolean weak reverse dependencies
 # http://rpm.org/user_doc/dependencies.html#weak-dependencies
 # http://rpm.org/user_doc/boolean_dependencies.html

--- a/dnfdaemon.spec
+++ b/dnfdaemon.spec
@@ -45,10 +45,10 @@ Summary:        SELinux integration for dnfdaemon
 
 Requires:       %{name} = %{version}-%{release}
 
-%if 0%{?fedora} >= 23 || 0%{?mageia} >= 6
+%if 0%{?fedora} >= 23 || 0%{?mageia} >= 6 || 0%{?rhel} >= 9
 Requires(post):     policycoreutils-python-utils
 Requires(postun):   policycoreutils-python-utils
-%elseif 0%{?rhel} >= 8
+%elseif 0%{?rhel} == 8
 Requires(post):     policycoreutils-python3
 Requires(postun):   policycoreutils-python3
 %else


### PR DESCRIPTION
On RHEL 8 the corresponding package is being called: `policycoreutils-python3`.
